### PR TITLE
feat: add global toast area

### DIFF
--- a/app.js
+++ b/app.js
@@ -224,10 +224,12 @@
   }
 
   function toast(text){
-    var fb = $('feedback');
-    if(!fb) return;
-    fb.innerHTML = '<div class="ok">'+text+'</div>';
-    setTimeout(function(){ if(fb) fb.innerHTML=''; }, 1000);
+    var t = $('toast');
+    if(!t) return;
+    t.textContent = text;
+    t.style.display = 'block';
+    clearTimeout(t._timer);
+    t._timer = setTimeout(function(){ t.style.display = 'none'; }, 1500);
   }
 
   // ====== Event delegation ======

--- a/index.html
+++ b/index.html
@@ -147,6 +147,8 @@
     </div>
   </div>
 
+  <div id="toast" class="toast" role="status" aria-live="polite" style="display:none"></div>
+
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function(){

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,12 @@ input.answer{
   box-shadow:0 10px 30px rgba(0,0,0,.25); text-align:center;
 }
 
+.toast{
+  position:fixed; bottom:20px; left:50%; transform:translateX(-50%);
+  background:var(--accent); color:#fff; padding:12px 16px; border-radius:999px;
+  box-shadow:0 2px 6px rgba(0,0,0,.2); display:none; z-index:10000;
+}
+
 .footer{ margin-top:24px; font-size:12px; color:var(--muted); }
 
 /* Tipografia mobile */


### PR DESCRIPTION
## Summary
- show toast messages in a fixed global area
- display setting toggle using the global toast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f45a2f40832da91de3e9935d7582