### PR TITLE
Add progress screen and improve answer feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,7 +114,7 @@
 
   // ====== Screens ======
   function show(id){
-    ['home','train','play'].forEach(function(s){
+    ['home','train','play','progress'].forEach(function(s){
       var elx = $(s);
       if(!elx) return;
       if(s===id){ elx.classList.remove('hidden'); }
@@ -341,12 +341,14 @@
   }
 
   function updateProgress(){
-    var g1 = $('goalBar'), g2 = $('goalBar2'), c1 = $('correctToday'), c2 = $('corToday2'), gSmall=$('goalSmall'), gVal=$('goalVal'), gVal2=$('goalVal2');
+    var g1 = $('goalBar'), g2 = $('goalBar2'), c1 = $('correctToday'), c2 = $('corToday2'), c3 = $('progCorrect'), gSmall=$('goalSmall'), gVal=$('goalVal'), gVal2=$('goalVal2'), gProg=$('progGoal');
     if(c1) c1.textContent = String(state.correctToday);
     if(c2) c2.textContent = String(state.correctToday);
+    if(c3) c3.textContent = String(state.correctToday);
     if(gSmall) gSmall.textContent = String(state.dailyGoal);
     if(gVal) gVal.textContent = String(state.dailyGoal);
     if(gVal2) gVal2.textContent = String(state.dailyGoal);
+    if(gProg) gProg.textContent = String(state.dailyGoal);
     var pct = Math.max(0, Math.min(100, Math.floor((state.correctToday/state.dailyGoal)*100)));
     [g1,g2].forEach(function(bar){ if(bar) bar.style.width = pct+'%'; });
     var streakLbl = $('streak'); if(streakLbl) streakLbl.textContent = String(state.streak);
@@ -361,18 +363,23 @@
   }
 
   function renderBadges(){
-    var play = $('badges'), earned = $('homeBadgesEarned'), locked = $('homeBadgesLocked');
+    var play = $('badges'),
+        earnedHome = $('homeBadgesEarned'),
+        lockedHome = $('homeBadgesLocked'),
+        earnedProg = $('progBadgesEarned'),
+        lockedProg = $('progBadgesLocked');
     if(play) play.innerHTML='';
-    if(earned) earned.innerHTML='';
-    if(locked) locked.innerHTML='';
+    [earnedHome,lockedHome,earnedProg,lockedProg].forEach(function(n){ if(n) n.innerHTML=''; });
     BADGES.forEach(function(b){
       var node = el('div', {'class':'badge', 'text':b.label});
       if(state.badges.indexOf(b.id)!==-1){
         if(play) play.appendChild(node.cloneNode(true));
-        if(earned) earned.appendChild(node);
+        if(earnedHome) earnedHome.appendChild(node.cloneNode(true));
+        if(earnedProg) earnedProg.appendChild(node);
       }else{
         var lock = el('div', {'class':'badge muted', 'text':b.label});
-        if(locked) locked.appendChild(lock);
+        if(lockedHome) lockedHome.appendChild(lock.cloneNode(true));
+        if(lockedProg) lockedProg.appendChild(lock);
       }
     });
   }
@@ -403,7 +410,7 @@
       if(id==='startQuick'){ e.preventDefault(); setTopic(null); show('play'); newQuestion(); renderQuestion(); toast('Via!'); return; }
       if(id==='startTrain'){ e.preventDefault(); show('train'); return; }
       if(id==='trainGo'){ e.preventDefault(); show('play'); newQuestion(); renderQuestion(); return; }
-      if(id==='btnProg'){ e.preventDefault(); alert('Corrette oggi: '+state.correctToday+'\nStreak: '+state.streak); return; }
+      if(id==='btnProg'){ e.preventDefault(); show('progress'); return; }
       if(id==='btnSettings'){ e.preventDefault(); state.autoAdvance=!state.autoAdvance; toast('Avanzamento automatico '+(state.autoAdvance?'ON':'OFF')); return; }
 
       if(id==='resetTopic' || id==='clearTopic'){ e.preventDefault(); setTopic(null); return; }

--- a/index.html
+++ b/index.html
@@ -106,14 +106,14 @@
 
         <div id="answerUI" class="mt10"></div>
 
+        <div id="feedback" class="mt10"></div>
+
         <div class="row gap mt10 align-center stack">
           <button class="btn" id="btnConfirm">Conferma</button>
           <button class="btn ghost" id="btnNext" disabled>Prossima</button>
           <button class="btn ghost" id="btnHint">Mostra hint</button>
           <button class="btn ghost" id="btnSimilar">Esempio simile</button>
         </div>
-
-        <div id="feedback" class="mt10"></div>
         <div id="hints" class="hint mt10 hidden"></div>
       </div>
 
@@ -127,6 +127,21 @@
           <div>Badge</div>
           <div id="badges" class="row gap mt6 wrap"></div>
         </div>
+      </div>
+    </section>
+
+    <!-- PROGRESSI -->
+    <section id="progress" class="screen hidden">
+      <div class="card">
+        <h2>Progressi</h2>
+        <div>Corrette oggi: <b id="progCorrect">0</b> / <b id="progGoal">20</b></div>
+      </div>
+      <div class="card">
+        <h2>🏅 Badge</h2>
+        <div class="kicker">Guadagnati</div>
+        <div id="progBadgesEarned" class="badges-grid mt6"></div>
+        <div class="kicker mt12">Da conquistare</div>
+        <div id="progBadgesLocked" class="badges-grid mt6"></div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Add Progress screen to show daily stats and list unlocked and locked badges
- Move answer feedback above control buttons for quicker visibility
- Extend badge rendering and navigation logic to support the new screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b30bb0f430832d99a3530c239fe75e