### PR TITLE
Add visible badge system with many achievements

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,8 +28,18 @@
   ];
 
   var BADGES = [
+    {id:'cor1', label:'1 risposta corretta', check:function(){ return state.totalCorrect >= 1; }},
     {id:'cor10', label:'10 risposte corrette', check:function(){ return state.totalCorrect >= 10; }},
-    {id:'streak5', label:'Streak di 5', check:function(){ return state.streak >= 5; }}
+    {id:'cor50', label:'50 risposte corrette', check:function(){ return state.totalCorrect >= 50; }},
+    {id:'cor100', label:'100 risposte corrette', check:function(){ return state.totalCorrect >= 100; }},
+    {id:'cor500', label:'500 risposte corrette', check:function(){ return state.totalCorrect >= 500; }},
+    {id:'cor1000', label:'1000 risposte corrette', check:function(){ return state.totalCorrect >= 1000; }},
+    {id:'streak5', label:'Streak di 5', check:function(){ return state.streak >= 5; }},
+    {id:'streak10', label:'Streak di 10', check:function(){ return state.streak >= 10; }},
+    {id:'streak20', label:'Streak di 20', check:function(){ return state.streak >= 20; }},
+    {id:'streak50', label:'Streak di 50', check:function(){ return state.streak >= 50; }},
+    {id:'dailyGoal', label:'Obiettivo quotidiano', check:function(){ return state.correctToday >= state.dailyGoal; }},
+    {id:'doubleGoal', label:'Raddoppia obiettivo', check:function(){ return state.correctToday >= state.dailyGoal*2; }}
   ];
 
   var state = {
@@ -371,15 +381,15 @@
     if(play) play.innerHTML='';
     [earnedHome,lockedHome,earnedProg,lockedProg].forEach(function(n){ if(n) n.innerHTML=''; });
     BADGES.forEach(function(b){
-      var node = el('div', {'class':'badge', 'text':b.label});
-      if(state.badges.indexOf(b.id)!==-1){
-        if(play) play.appendChild(node.cloneNode(true));
-        if(earnedHome) earnedHome.appendChild(node.cloneNode(true));
-        if(earnedProg) earnedProg.appendChild(node);
+      var earned = state.badges.indexOf(b.id)!==-1;
+      var badge = el('div', {'class':'badge'+(earned?'':' muted'), 'text':b.label});
+      if(play) play.appendChild(badge.cloneNode(true));
+      if(earned){
+        if(earnedHome) earnedHome.appendChild(badge.cloneNode(true));
+        if(earnedProg) earnedProg.appendChild(badge.cloneNode(true));
       }else{
-        var lock = el('div', {'class':'badge muted', 'text':b.label});
-        if(lockedHome) lockedHome.appendChild(lock.cloneNode(true));
-        if(lockedProg) lockedProg.appendChild(lock);
+        if(lockedHome) lockedHome.appendChild(badge.cloneNode(true));
+        if(lockedProg) lockedProg.appendChild(badge.cloneNode(true));
       }
     });
   }

--- a/index.html
+++ b/index.html
@@ -54,6 +54,14 @@
       </div>
 
       <div class="card">
+        <h2>🏅 Badge</h2>
+        <div class="kicker">Guadagnati</div>
+        <div id="homeBadgesEarned" class="badges-grid mt6"></div>
+        <div class="kicker mt12">Da conquistare</div>
+        <div id="homeBadgesLocked" class="badges-grid mt6"></div>
+      </div>
+
+      <div class="card">
         <div class="row space-between align-center">
           <div>
             <div class="kicker">Cambia argomento rapido</div>
@@ -61,14 +69,6 @@
           </div>
           <div><button class="btn ghost" id="clearTopic">Nessun filtro</button></div>
         </div>
-      </div>
-
-      <div class="card">
-        <h2>🏅 Badge</h2>
-        <div class="kicker">Guadagnati</div>
-        <div id="homeBadgesEarned" class="badges-grid mt6"></div>
-        <div class="kicker mt12">Da conquistare</div>
-        <div id="homeBadgesLocked" class="badges-grid mt6"></div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Expand badge list with milestones for total answers and streaks
- Show locked and earned badges in play and progress views
- Move badge card higher on home screen for visibility

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b30f16cc0c832d8f8ccf0237892281