### PR TITLE
Badge colorati e celebrazione

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,8 @@
     {id:'doubleGoal', label:'Raddoppia obiettivo', check:function(){ return state.correctToday >= state.dailyGoal*2; }}
   ];
 
+  var BADGE_COLORS = ['#ef4444','#f59e0b','#10b981','#3b82f6','#8b5cf6','#ec4899'];
+
   var state = {
     screen:'home',
     difficulty: 2,
@@ -372,6 +374,23 @@
     setTimeout(function(){ if(fb) fb.innerHTML=''; }, 1000);
   }
 
+  function celebrateBadge(name){
+    var ov = $('badgeOverlay');
+    var lbl = $('badgeName');
+    if(!ov || !lbl) return;
+    lbl.textContent = name;
+    ov.style.display = 'flex';
+    ov.setAttribute('aria-hidden','false');
+    setTimeout(hideBadgeOverlay, 3000);
+  }
+
+  function hideBadgeOverlay(){
+    var ov = $('badgeOverlay');
+    if(!ov) return;
+    ov.style.display = 'none';
+    ov.setAttribute('aria-hidden','true');
+  }
+
   function renderBadges(){
     var play = $('badges'),
         earnedHome = $('homeBadgesEarned'),
@@ -380,9 +399,10 @@
         lockedProg = $('progBadgesLocked');
     if(play) play.innerHTML='';
     [earnedHome,lockedHome,earnedProg,lockedProg].forEach(function(n){ if(n) n.innerHTML=''; });
-    BADGES.forEach(function(b){
+    BADGES.forEach(function(b, i){
       var earned = state.badges.indexOf(b.id)!==-1;
       var badge = el('div', {'class':'badge'+(earned?'':' muted'), 'text':b.label});
+      badge.style.backgroundColor = BADGE_COLORS[i % BADGE_COLORS.length];
       if(play) play.appendChild(badge.cloneNode(true));
       if(earned){
         if(earnedHome) earnedHome.appendChild(badge.cloneNode(true));
@@ -399,7 +419,7 @@
       if(state.badges.indexOf(b.id)===-1 && b.check()){
         state.badges.push(b.id);
         localStorage.setItem('badges', JSON.stringify(state.badges));
-        toast('Nuovo badge: '+b.label+'!');
+        celebrateBadge(b.label);
         renderBadges();
       }
     });
@@ -437,6 +457,7 @@
       if(id==='btnHint'){ e.preventDefault(); var h=$('hints'); h.textContent='Suggerimento: prova a scomporre il calcolo.'; h.classList.remove('hidden'); return; }
       if(id==='btnSimilar'){ e.preventDefault(); toast('Esempio simile: tra poco!'); return; }
       if(id==='btnHomeNow'){ e.preventDefault(); show('home'); return; }
+      if(id==='badgeClose'){ e.preventDefault(); hideBadgeOverlay(); return; }
     }, {passive:false});
   }
 

--- a/index.html
+++ b/index.html
@@ -162,6 +162,14 @@
     </div>
   </div>
 
+  <div class="overlay" id="badgeOverlay" aria-hidden="true" style="display:none">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="badgeTitle">
+      <h2 id="badgeTitle">🏅 Nuovo badge!</h2>
+      <div class="kicker">Hai sbloccato: <b id="badgeName"></b></div>
+      <button class="btn" id="badgeClose">Fantastico!</button>
+    </div>
+  </div>
+
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function(){

--- a/styles.css
+++ b/styles.css
@@ -66,7 +66,8 @@ input.answer{
 
 /* Badge / Mastery */
 .badges-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(180px,1fr)); gap:10px; }
-.badge{ display:inline-flex; align-items:center; gap:8px; border:1px solid #111; border-radius:999px; padding:6px 10px; background:#fff; }
+.badge{ display:inline-flex; align-items:center; gap:8px; border-radius:999px; padding:6px 10px; color:#fff; font-weight:700; }
+.badge.muted{ filter:grayscale(1); opacity:.5; color:#fff; }
 
 .mastery-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(220px,1fr)); gap:10px; }
 .mastery-tile{ border:1px solid #111; border-radius:14px; background:#fff; padding:12px; }


### PR DESCRIPTION
## Summary
- Aggiunta tavolozza colori per i badge e visualizzazione cromatica
- Nuovo overlay di celebrazione quando si sblocca un badge
- Stile dei badge aggiornato con versione mutata per quelli bloccati

## Testing
- `npm test` *(fallito: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b315341648832db309a13042a8729b