### PR TITLE
Fix mobile input overflow and bump to v19.01

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-<title>MathQuest Lite Plus · 1ª–2ª media (v12)</title>
+<title>MathQuest Lite Plus · 1ª–2ª media (v19.01)</title>
 <link rel="manifest" href="./manifest.webmanifest">
 <style>
   :root{--bg:#f5f7ff;--fg:#111;--accent:#111;--muted:#6b7280;--accent2:#2563eb;--accent3:#0ea5e9;--accent4:#10b981;--accent5:#f59e0b;--accent6:#ec4899}
@@ -19,7 +19,7 @@
   .pill.active{background:#111;color:#fff}
   .progress{height:10px;background:#e5e7eb;border-radius:8px;overflow:hidden}
   .bar{height:100%;background:var(--accent);width:0%}
-  input.answer{width:100%;padding:12px;border:1px solid #111;border-radius:12px;font-size:18px}
+  input.answer{width:100%;padding:12px;border:1px solid #111;border-radius:12px;font-size:18px;box-sizing:border-box}
   .hint{background:#e0f2fe;border-radius:12px;padding:10px;font-size:14px;white-space:pre-wrap}
   .ok{background:#dcfce7;border-radius:12px;padding:10px}
   .bad{background:#fef9c3;border-radius:12px;padding:10px}
@@ -59,7 +59,7 @@
 <body>
   <div class="wrap">
     <header class="row" style="justify-content:space-between;align-items:center">
-      <h1>MathQuest Lite Plus · 1ª–2ª media (v12)</h1>
+      <h1>MathQuest Lite Plus · 1ª–2ª media (v19.01)</h1>
       <div class="row" style="align-items:center">
         <span style="font-size:14px;color:var(--muted)">Difficoltà</span>
         <div id="levels" class="row"></div>

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
-/* sw.js — MathQuest PWA — v12
+/* sw.js — MathQuest PWA — v19.01
    - Navigazioni (document): NETWORK-FIRST con fallback offline (index.html)
    - Asset statici: CACHE-FIRST con fill dinamico
 */
-const VERSION    = 'v12';
+const VERSION    = 'v19.01';
 const CACHE_NAME = `mathquest-${VERSION}`;
 
 const PRECACHE = [


### PR DESCRIPTION
## Summary
- ensure answer text field fits within mobile screens
- bump app and service worker version to v19.01

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b33c4c3624832da6f9707bac1e46b7