### PR TITLE
Handle comma decimal separator and robust answer comparison

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-/* MathQuest – app.js v18.4 (render domanda+risposte visibili) */
+/* MathQuest – app.js v19.03 (render domanda+risposte visibili) */
 (function(){
   // ===== Util =====
   function $(id){ return document.getElementById(id); }

--- a/app.js
+++ b/app.js
@@ -301,7 +301,7 @@
       });
       ans.appendChild(wrap);
     }else{
-      var inp = el('input', {'class':'answer', 'type':'number', 'id':'answerInput', 'inputmode':'numeric'});
+      var inp = el('input', {'class':'answer', 'type':'text', 'id':'answerInput', 'inputmode':'decimal'});
       ans.appendChild(inp);
       setTimeout(function(){ inp.focus(); }, 50);
     }
@@ -328,7 +328,18 @@
       user = inp ? inp.value : '';
       if(user===''){ toast('Inserisci una risposta'); if(bc) bc.disabled=false; return false; }
     }
-    var isCorrect = Number(user) === Number(state.q.correct);
+    function normalize(v){
+      if(typeof v === 'string'){
+        v = v.trim().replace(',', '.');
+      }
+      return v;
+    }
+    var userNorm = normalize(user);
+    var correctNorm = normalize(state.q.correct);
+    var userNum = Number(userNorm);
+    var correctNum = Number(correctNorm);
+    var isNumeric = !isNaN(userNum) && !isNaN(correctNum);
+    var isCorrect = isNumeric ? userNum === correctNum : String(userNorm) === String(correctNorm);
     var fb = $('feedback');
     fb.innerHTML = isCorrect
       ? '<div class="ok">✅ Corretto!</div>'

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="it">
 <head>
   <meta charset="utf-8" />
-  <title>MathQuest · 1ª–2ª media (v18.4)</title>
+  <title>MathQuest · 1ª–2ª media (v19.03)</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -10,15 +10,15 @@
   <meta name="apple-mobile-web-app-title" content="MathQuest">
   <meta name="format-detection" content="telephone=no">
 
-  <link rel="manifest" href="manifest.webmanifest?v=184">
+  <link rel="manifest" href="manifest.webmanifest?v=1903">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
-  <link rel="stylesheet" href="styles.css?v=184">
+  <link rel="stylesheet" href="styles.css?v=1903">
 </head>
 <body>
   <div class="wrap">
     <header class="row space-between align-center">
       <h1 class="app-title">MathQuest <span class="kicker">1ª–2ª media</span></h1>
-      <div class="version-badge">v18.4</div>
+      <div class="version-badge">v19.03</div>
     </header>
 
     <nav class="row gap nav-grid">
@@ -147,7 +147,7 @@
 
     <footer class="footer">
       <div>Consigli: 10–15 min al giorno. Privacy: dati solo in locale.</div>
-      <div class="muted">Build: <b>v18.4</b></div>
+      <div class="muted">Build: <b>v19.03</b></div>
     </footer>
   </div>
 
@@ -165,11 +165,11 @@
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function(){
-        navigator.serviceWorker.register('sw.js?v=184').catch(function(e){ console.log('SW reg error', e); });
+        navigator.serviceWorker.register('sw.js?v=1903').catch(function(e){ console.log('SW reg error', e); });
       });
     }
   </script>
 
-  <script src="app.js?v=184" defer></script>
+  <script src="app.js?v=1903" defer></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-// sw.js v18.4 – cache-busting
-const VERSION = 'v184';
+// sw.js v19.03 – cache-busting
+const VERSION = 'v1903';
 const CACHE_NAME = `mathquest-${VERSION}`;
 
 const scopeURL = new URL(self.registration.scope);


### PR DESCRIPTION
## Summary
- Allow decimal inputs using commas by normalizing them before evaluation
- Compare answers as numbers when possible and as strings otherwise
- Use a text input with decimal keyboard for free-form answers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b341d07414832d93e506a81f5bef58