### PR TITLE
feat: enable numeric keyboard for open answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-<title>MathQuest Lite Plus · 1ª–2ª media (v19)</title>
+<title>MathQuest Lite Plus · 1ª–2ª media (v19.05)</title>
 <link rel="manifest" href="./manifest.webmanifest">
 <style>
   :root{--bg:#f5f7ff;--fg:#111;--accent:#111;--muted:#6b7280;--accent2:#2563eb;--accent3:#0ea5e9;--accent4:#10b981;--accent5:#f59e0b;--accent6:#ec4899}
@@ -59,7 +59,7 @@
 <body>
   <div class="wrap">
     <header class="row" style="justify-content:space-between;align-items:center">
-      <h1>MathQuest Lite Plus · 1ª–2ª media (v19)</h1>
+      <h1>MathQuest Lite Plus · 1ª–2ª media (v19.05)</h1>
       <div class="row" style="align-items:center">
         <span style="font-size:14px;color:var(--muted)">Difficoltà</span>
         <div id="levels" class="row"></div>
@@ -685,7 +685,7 @@ function renderQuestion(){
     });
     ui.appendChild(grid);
   } else {
-    var inp=document.createElement('input'); inp.type='text'; inp.className='answer'; inp.placeholder='Scrivi qui la risposta';
+    var inp=document.createElement('input'); inp.type='text'; inp.inputMode='decimal'; inp.className='answer'; inp.placeholder='Scrivi qui la risposta';
     inp.onkeydown=function(e){ if(e.key==='Enter'){ confirmAnswer(); } };
     inp.oninput=function(e){ state.input=e.target.value; };
     ui.appendChild(inp); inp.focus();
@@ -717,7 +717,7 @@ function maybeCompleteGoal(){
 function confirmAnswer(){
   if(!state.question || state.answeredThis) return;
   var ok=false; var ans = state.question.answer;
-  if(typeof ans==='number'){ ok = approxEqual(Number(state.input), ans); }
+  if(typeof ans==='number'){ var normalized=String(state.input).replace(',', '.'); ok = approxEqual(Number(normalized), ans); }
   else { ok = String(state.input).trim()===String(ans).trim(); }
 
   state.answered++;

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
-/* sw.js — MathQuest PWA — v19
+/* sw.js — MathQuest PWA — v19.05
    - Navigazioni (document): NETWORK-FIRST con fallback offline (index.html)
    - Asset statici: CACHE-FIRST con fill dinamico
 */
-const VERSION    = 'v19';
+const VERSION    = 'v19.05';
 const CACHE_NAME = `mathquest-${VERSION}`;
 
 const PRECACHE = [


### PR DESCRIPTION
## Summary
- show numeric keyboard for free-form answers
- allow comma or dot decimal separators
- bump version to v19.05

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34a3e68bc832da5081c708d2b6191